### PR TITLE
Fix balance defaults and improve user persistence

### DIFF
--- a/financial_service.py
+++ b/financial_service.py
@@ -492,7 +492,7 @@ class FinancialService:
     def _create_user_if_not_exists(self, conn, cursor, telegram_id: int) -> Dict:
         """Создание пользователя если не существует"""
         
-        initial_balance = 200  # Начальный баланс
+        initial_balance = 50  # Начальный баланс совпадает с бизнес-логикой
         
         if self.db.DB_CONFIG['type'] == 'postgresql':
             query = """
@@ -525,7 +525,7 @@ class FinancialService:
             cursor.execute("SELECT balance FROM users WHERE telegram_id = ?", (telegram_id,))
         
         result = cursor.fetchone()
-        return result[0] if result else 200
+        return result[0] if result else 50
     
     # BACKWARD COMPATIBILITY: обертки для старых методов
     def update_user_balance(self, telegram_id: int, amount_change: int, 

--- a/payment_service.py
+++ b/payment_service.py
@@ -57,7 +57,7 @@ class PaymentService:
             # 2. Подготовка данных для ЮKassa с обязательным чеком
             payment_data = {
                 "amount": {
-                    "value": f"{amount:.1f}",
+                    "value": f"{amount:.2f}",
                     "currency": "RUB"
                 },
                 "confirmation": {


### PR DESCRIPTION
## Summary
- align FinancialService user creation with the 50 STcoin initial balance
- format YooKassa payment amount values with two decimal places to satisfy the API requirements
- persist users without INSERT OR REPLACE so existing records keep their ids and balance

## Testing
- python -m compileall financial_service.py payment_service.py database.py

------
https://chatgpt.com/codex/tasks/task_e_68ce351bc92c83308d0b9571fb78d7f5